### PR TITLE
Accounts List Changes

### DIFF
--- a/bundle/fields/uesio/crm/account/description.yaml
+++ b/bundle/fields/uesio/crm/account/description.yaml
@@ -1,4 +1,3 @@
 name: description
 label: Description
 type: LONGTEXT
-required: true

--- a/bundle/views/account_list.yaml
+++ b/bundle/views/account_list.yaml
@@ -87,7 +87,7 @@ definition:
                                   sourceValue: $ComponentState{[uesio/io.table][accountTable][mode]}
                                   value: EDIT
                           text: $Label{uesio/io.cancel}
-                          uesio.variant: uesio/io.secondary
+                          uesio.variant: uesio/crm.secondary
                       - uesio/io.button:
                           signals:
                             - signal: component/CALL
@@ -101,7 +101,7 @@ definition:
                               operator: NOT_EQUALS
                               sourceValue: $ComponentState{[uesio/io.table][accountTable][mode]}
                           text: Edit
-                          uesio.variant: uesio/io.secondary
+                          uesio.variant: uesio/crm.secondary
                           icon: edit_square
                           iconFill: false
                     linkedComponentType: uesio/io.table
@@ -111,7 +111,7 @@ definition:
                     text: domain
                     uesio.variant: uesio/io.icon
           - uesio/io.box:
-              uesio.variant: uesio/io.section
+              uesio.variant: uesio/crm.primarysection
               components:
                 - uesio/io.toolbar:
                     left:
@@ -125,24 +125,18 @@ definition:
                       - uesio/io.button:
                           text: Quick Create
                           icon: add_circle
-                          uesio.variant: uesio/io.primary
-                          iconPlacement: ""
+                          uesio.variant: uesio/crm.add
                           signals:
                             - signal: wire/CREATE_RECORD
                               wire: account
                               prepend: true
-                          uesio.styleTokens:
-                            root:
-                              - bg-emerald-600
-                              - border-emerald-600
                           uesio.display:
                             - type: mergeValue
                               value: EDIT
                               sourceValue: $ComponentState{[uesio/io.table][accountTable][mode]}
                       - uesio/io.button:
-                          text: Mark for Delete
                           icon: delete
-                          uesio.variant: uesio/crm.primary
+                          uesio.variant: uesio/crm.delete
                           signals:
                             - signal: component/CALL
                               component: uesio/io.table

--- a/bundle/views/account_list.yaml
+++ b/bundle/views/account_list.yaml
@@ -26,6 +26,10 @@ definition:
         uesio/crm.shipping_street:
         uesio/crm.shipping_zip:
         uesio/crm.website: # Components determine the layout and composition of your view
+        uesio/crm.initials: {}
+      order:
+        - desc: false
+          field: uesio/crm.name
   components:
     - uesio/io.viewlayout:
         left:
@@ -36,28 +40,24 @@ definition:
               subtitle: List View
               uesio.variant: uesio/crm.main
               actions:
-                - uesio/io.group:
-                    components:
-                      - uesio/io.button:
-                          signals:
-                            - signal: wire/CREATE_RECORD
-                              wire: account
-                              prepend: true
-                            - signal: component/CALL
-                              component: uesio/io.table
-                              componentsignal: SET_EDIT_MODE
-                              targettype: specific
-                              componentid: accountTable
-                          text: $Label{uesio/io.create}
-                          uesio.variant: uesio/crm.primary
+                - uesio/io.toolbar:
+                    right:
                       - uesio/io.button:
                           signals:
                             - signal: wire/SAVE
                               wires:
                                 - account
+                            - signal: component/CALL
+                              component: uesio/io.table
+                              componentsignal: SET_READ_MODE
+                              targettype: specific
+                              componentid: accountTable
+                            - signal: wire/LOAD
+                              wires:
+                                - account
                           text: $Label{uesio/io.save}
                           hotkey: "meta+s"
-                          uesio.variant: uesio/io.secondary
+                          uesio.variant: uesio/crm.primary
                           uesio.display:
                             - type: wireHasChanges
                               wire: account
@@ -65,9 +65,27 @@ definition:
                           signals:
                             - signal: wire/CANCEL
                               wire: account
+                            - signal: component/CALL
+                              component: uesio/io.table
+                              componentsignal: SET_READ_MODE
+                              targettype: specific
+                              componentid: accountTable
+                            - signal: component/CALL
+                              component: uesio/io.table
+                              componentsignal: CLEAR_SELECTED
+                              targettype: specific
+                              componentid: accountTable
                           uesio.display:
-                            - type: wireHasChanges
-                              wire: account
+                            - type: group
+                              conjunction: OR
+                              conditions:
+                                - type: wireHasChanges
+                                  operator: EQUALS
+                                  wire: account
+                                - type: mergeValue
+                                  operator: ""
+                                  sourceValue: $ComponentState{[uesio/io.table][accountTable][mode]}
+                                  value: EDIT
                           text: $Label{uesio/io.cancel}
                           uesio.variant: uesio/io.secondary
                       - uesio/io.button:
@@ -77,16 +95,73 @@ definition:
                               componentsignal: TOGGLE_MODE
                               targettype: specific
                               componentid: accountTable
-                          text: Mode
+                          uesio.display:
+                            - type: mergeValue
+                              value: EDIT
+                              operator: NOT_EQUALS
+                              sourceValue: $ComponentState{[uesio/io.table][accountTable][mode]}
+                          text: Edit
                           uesio.variant: uesio/io.secondary
+                          icon: edit_square
+                          iconFill: false
+                    linkedComponentType: uesio/io.table
+                    linkedComponentId: accountTable
+              avatar:
+                - uesio/io.text:
+                    text: domain
+                    uesio.variant: uesio/io.icon
           - uesio/io.box:
               uesio.variant: uesio/io.section
               components:
+                - uesio/io.toolbar:
+                    left:
+                      - uesio/io.searchbox:
+                          wire: account
+                          searchFields:
+                            - uesio/crm.name
+                          placeholder: Search Accounts
+                          uesio.variant: uesio/crm.main
+                    right:
+                      - uesio/io.button:
+                          text: Quick Create
+                          icon: add_circle
+                          uesio.variant: uesio/io.primary
+                          iconPlacement: ""
+                          signals:
+                            - signal: wire/CREATE_RECORD
+                              wire: account
+                              prepend: true
+                          uesio.styleTokens:
+                            root:
+                              - bg-emerald-600
+                              - border-emerald-600
+                          uesio.display:
+                            - type: mergeValue
+                              value: EDIT
+                              sourceValue: $ComponentState{[uesio/io.table][accountTable][mode]}
+                      - uesio/io.button:
+                          text: Mark for Delete
+                          icon: delete
+                          uesio.variant: uesio/crm.primary
+                          signals:
+                            - signal: component/CALL
+                              component: uesio/io.table
+                              componentsignal: GET_SELECTED
+                              targettype: specific
+                              componentid: accountTable
+                            - signal: wire/TOGGLE_DELETE_STATUS
+                          uesio.display:
+                            - type: hasValue
+                              value: $ComponentState{[uesio/io.table][accountTable][selected->count]}
+                    linkedComponentType: uesio/io.table
+                    linkedComponentId: accountTable
                 - uesio/io.table:
                     uesio.variant: uesio/crm.main
+                    selectable: true
                     rowactions:
                       - icon: visibility
                         text: View
+                        type: DEFAULT
                         uesio.display:
                           - type: recordIsNotNew
                         signals:
@@ -94,17 +169,19 @@ definition:
                             viewtype: detail
                             recordid: ${uesio/core.id}
                             collection: uesio/crm.account
-                      - icon: delete
-                        text: $Label{uesio/io.delete}
-                        signals:
-                          - signal: wire/TOGGLE_DELETE_STATUS
-                            wire: account
                     columns:
+                      - components:
+                          - uesio/io.avatar:
+                              text: ${initials}
+                              image: $UserFile{uesio/crm.logo}
+                              uesio.styleTokens:
+                                root:
+                                  - m-auto
                       - field: uesio/crm.name
-                      - field: uesio/crm.annual_revenue
-                      - field: uesio/crm.description
+                      - field: uesio/crm.account_type
                       - field: uesio/crm.industry
-                      - field: uesio/crm.no_employees
+                      - field: uesio/crm.phone
+                      - field: uesio/crm.billing_city
                       - field: uesio/crm.website
                     uesio.id: accountTable
                     mode: READ

--- a/bundle/views/lead_list.yaml
+++ b/bundle/views/lead_list.yaml
@@ -83,7 +83,7 @@ definition:
                                   value: EDIT
                                   sourceValue: $ComponentState{[uesio/io.table][leadTable][mode]}
                           text: $Label{uesio/io.cancel}
-                          uesio.variant: uesio/io.secondary
+                          uesio.variant: uesio/crm.secondary
                       - uesio/io.button:
                           signals:
                             - signal: component/CALL
@@ -99,7 +99,7 @@ definition:
                           text: Edit
                           icon: edit_square
                           iconFill: false
-                          uesio.variant: uesio/io.secondary
+                          uesio.variant: uesio/crm.secondary
           - uesio/io.box:
               uesio.variant: uesio/crm.primarysection
               components:


### PR DESCRIPTION
Added:
- On click to route
- Edit, mark for delete, save, cancel, quick create
- Initial in table
- Multi select in table
- More appropriate fields also to avoid grey fields 
- On save reload wire after Quick Create to order list 
- Ordered account wire by name

Removed:
- Account Collection description required field