### PR TITLE
Add rating stoplight

### DIFF
--- a/bundle/componentpacks/main/pack.yaml
+++ b/bundle/componentpacks/main/pack.yaml
@@ -1,0 +1,1 @@
+name: main

--- a/bundle/componentpacks/main/src/components/stoplight/stoplight.tsx
+++ b/bundle/componentpacks/main/src/components/stoplight/stoplight.tsx
@@ -1,0 +1,51 @@
+import { styles, definition, component } from "@uesio/ui"
+
+type ComponentDefinition = {
+	field: string
+}
+
+const StyleDefaults = Object.freeze({
+	root: ["absolute", "flex", "bottom-0", "right-0", "gap-0.5"],
+	circle: ["text-slate-200", "text-xs", "leading-none"],
+	warm: ["text-yellow-400"],
+	hot: ["text-red-500"],
+	cold: ["text-sky-300"],
+})
+
+const Component: definition.UC<ComponentDefinition> = (props) => {
+	const { context } = props
+	const { field } = props.definition
+	const Icon = component.getUtility("uesio/io.icon")
+	const classes = styles.useStyleTokens(StyleDefaults, props)
+	const value = context.getRecord()?.getFieldValue(field)
+	return (
+		<div className={classes.root}>
+			<Icon
+				className={styles.cx(
+					classes.circle,
+					value === "Cold" && classes.cold
+				)}
+				icon="ac_unit"
+				context={context}
+			/>
+			<Icon
+				className={styles.cx(
+					classes.circle,
+					value === "Warm" && classes.warm
+				)}
+				icon="partly_cloudy_day"
+				context={context}
+			/>
+			<Icon
+				className={styles.cx(
+					classes.circle,
+					value === "Hot" && classes.hot
+				)}
+				icon="local_fire_department"
+				context={context}
+			/>
+		</div>
+	)
+}
+
+export default Component

--- a/bundle/components/stoplight.yaml
+++ b/bundle/components/stoplight.yaml
@@ -1,0 +1,19 @@
+name: stoplight
+category: DATA
+pack: main
+entrypoint: components/stoplight/stoplight
+title: Stoplight
+discoverable: true
+description: A stoplight component for ratings
+properties:
+  - name: field
+    label: Field
+    required: true
+    type: FIELD
+defaultDefinition:
+sections:
+  - type: HOME
+    properties:
+      - field
+  - type: STYLES
+  - type: DISPLAY

--- a/bundle/componentvariants/uesio/io/tile/item.yaml
+++ b/bundle/componentvariants/uesio/io/tile/item.yaml
@@ -10,3 +10,4 @@ definition:
       - p-2
       - hover:bg-slate-100
       - rounded
+      - relative

--- a/bundle/views/home.yaml
+++ b/bundle/views/home.yaml
@@ -30,6 +30,7 @@ definition:
         uesio/crm.firstname:
         uesio/crm.lastname:
         uesio/crm.email:
+        uesio/crm.lead_rating:
         uesio/crm.initials:
         uesio/crm.source:
           fields:
@@ -151,6 +152,8 @@ definition:
                                                               uesio.variant: uesio/crm.badge
                                                               element: div
                                                               text: ${source->uesio/core.uniquekey}
+                                                          - uesio/crm.stoplight:
+                                                              field: lead_rating
                                                   avatar:
                                                     - uesio/io.avatar:
                                                         text: ${initials}


### PR DESCRIPTION
Adds a rating stoplight component to the home page.
<img width="371" alt="Screenshot 2024-04-30 at 11 58 09 AM" src="https://github.com/ues-io/crm/assets/55447225/c78dd943-44ce-4705-bf18-36d001e187c1">
