### PR TITLE
Add Lead Images

### DIFF
--- a/bundle/componentvariants/uesio/io/avatar/main.yaml
+++ b/bundle/componentvariants/uesio/io/avatar/main.yaml
@@ -1,0 +1,11 @@
+name: main
+label: Main
+public: true
+extends: uesio/io.default
+definition:
+  uesio.styleTokens:
+    root:
+      - w-12
+      - h-12
+      - rounded-md
+      - text-xl

--- a/bundle/componentvariants/uesio/io/avatar/main_pointer.yaml
+++ b/bundle/componentvariants/uesio/io/avatar/main_pointer.yaml
@@ -1,0 +1,8 @@
+name: main_pointer
+label: Main Pointer
+public: true
+extends: uesio/crm.main
+definition:
+  uesio.styleTokens:
+    root:
+      - cursor-pointer

--- a/bundle/componentvariants/uesio/io/menu/upload.yaml
+++ b/bundle/componentvariants/uesio/io/menu/upload.yaml
@@ -1,0 +1,10 @@
+name: upload
+label: Upload Menu
+extends: uesio/io.default
+definition:
+  uesio.styleTokens:
+    menu:
+      - w-72
+      - py-6
+      - px-8
+public: true

--- a/bundle/componentvariants/uesio/io/titlebar/main.yaml
+++ b/bundle/componentvariants/uesio/io/titlebar/main.yaml
@@ -13,7 +13,3 @@ definition:
       - border-0
       - text-rose-800
       - text-3xl
-      - "[&>div]:w-12"
-      - "[&>div]:h-12"
-      - "[&>div]:rounded-md"
-      - "[&>div]:text-xl"

--- a/bundle/fields/uesio/crm/lead/image.yaml
+++ b/bundle/fields/uesio/crm/lead/image.yaml
@@ -1,0 +1,5 @@
+name: image
+label: Image
+type: FILE
+file:
+  accept: IMAGE

--- a/bundle/views/home.yaml
+++ b/bundle/views/home.yaml
@@ -31,6 +31,7 @@ definition:
         uesio/crm.lastname:
         uesio/crm.email:
         uesio/crm.lead_rating:
+        uesio/crm.image:
         uesio/crm.initials:
         uesio/crm.source:
           fields:
@@ -181,6 +182,7 @@ definition:
                                                   avatar:
                                                     - uesio/io.avatar:
                                                         text: ${initials}
+                                                        image: $UserFile{image}
                                                   signals:
                                                     - signal: route/NAVIGATE_TO_ASSIGNMENT
                                                       collection: uesio/crm.lead

--- a/bundle/views/lead_detail_content.yaml
+++ b/bundle/views/lead_detail_content.yaml
@@ -23,6 +23,7 @@ definition:
         uesio/crm.phone_business:
         uesio/crm.phone_mobile:
         uesio/crm.topic:
+        uesio/crm.image:
         uesio/crm.website:
         uesio/crm.company: {}
         uesio/core.id: {}
@@ -231,9 +232,27 @@ definition:
                                 text: Read
                                 uesio.variant: uesio/crm.secondary
                     avatar:
-                      - uesio/io.avatar:
-                          text: ${initials}
-                          image: $UserFile{uesio/crm.logo}
+                      - uesio/io.menu:
+                          uesio.variant: uesio/crm.upload
+                          arrow: true
+                          closeButton: true
+                          trigger:
+                            - uesio/io.avatar:
+                                uesio.variant: uesio/crm.main_pointer
+                                text: ${initials}
+                                image: $UserFile{uesio/crm.image}
+                          content:
+                            - uesio/io.box:
+                                components:
+                                  - uesio/io.titlebar:
+                                      uesio.variant: uesio/crm.sub
+                                      title: Upload or Delete Lead Image
+                                  - uesio/io.field:
+                                      labelPosition: none
+                                      uesio.context:
+                                        fieldMode: EDIT
+                                      fieldId: uesio/crm.image
+                                      displayAs: IMAGE
                 - uesio/io.box:
                     uesio.variant: uesio/crm.primarysection
                     components:

--- a/bundle/views/lead_list.yaml
+++ b/bundle/views/lead_list.yaml
@@ -25,6 +25,7 @@ definition:
         uesio/crm.topic:
         uesio/crm.website:
         uesio/crm.initials:
+        uesio/crm.image:
   components:
     - uesio/io.viewlayout:
         left:
@@ -175,6 +176,7 @@ definition:
                                 root:
                                   - m-auto
                               text: ${initials}
+                              image: $UserFile{uesio/crm.image}
                       - field: uesio/crm.firstname
                       - field: uesio/crm.lastname
                       - field: uesio/crm.email


### PR DESCRIPTION
1. Adds the ability to upload an image on the lead detail page.
2. Adds image to all places where the lead avatar is used.

<img width="894" alt="Screenshot 2024-05-01 at 5 12 52 PM" src="https://github.com/ues-io/crm/assets/55447225/1af2da95-2bf5-421e-a619-bc025b896d28">

<img width="408" alt="Screenshot 2024-05-01 at 5 44 13 PM" src="https://github.com/ues-io/crm/assets/55447225/57e0143b-dfac-420b-9587-39a581fab3b1">

<img width="1558" alt="Screenshot 2024-05-01 at 5 44 28 PM" src="https://github.com/ues-io/crm/assets/55447225/63baa2b1-eb50-4a32-8c30-d7afb9ed3c9e">
