### PR TITLE
owner_filter

### DIFF
--- a/bundle/views/account_list.yaml
+++ b/bundle/views/account_list.yaml
@@ -27,6 +27,7 @@ definition:
         uesio/crm.shipping_zip:
         uesio/crm.website:
         uesio/crm.initials:
+        uesio/core.owner: {}
       batchsize: 200
       order:
         - desc: false
@@ -58,6 +59,12 @@ definition:
                     placeholder: Search Accounts
                     searchFields:
                       - uesio/crm.name
+                - uesio/io.filter:
+                    uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
+                    wire: account
+                    fieldId: uesio/core.owner
+                    labelPosition: none
+                    displayAs: MULTISELECT
                 - uesio/io.filter:
                     uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
                     wire: account

--- a/bundle/views/contact_list.yaml
+++ b/bundle/views/contact_list.yaml
@@ -29,6 +29,7 @@ definition:
         uesio/crm.salutation:
         uesio/crm.title:
         uesio/crm.initials:
+        uesio/core.owner: {}
       batchsize: 200
       order:
         - desc: false
@@ -62,6 +63,12 @@ definition:
                       - uesio/crm.firstname
                       - uesio/crm.fullname
                       - uesio/crm.lastname
+                - uesio/io.filter:
+                    uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
+                    wire: contact
+                    fieldId: uesio/core.owner
+                    labelPosition: none
+                    displayAs: MULTISELECT
                 - uesio/io.filter:
                     uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
                     wire: contact

--- a/bundle/views/event_list.yaml
+++ b/bundle/views/event_list.yaml
@@ -14,6 +14,7 @@ definition:
         uesio/crm.name:
         uesio/crm.starttime:
         uesio/crm.initials:
+        uesio/core.owner: {}
       batchsize: 200
       order:
         - desc: false
@@ -45,6 +46,12 @@ definition:
                     placeholder: Search Events
                     searchFields:
                       - uesio/crm.name
+                - uesio/io.filter:
+                    uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
+                    wire: events
+                    fieldId: uesio/core.owner
+                    labelPosition: none
+                    displayAs: MULTISELECT
               content:
                 - uesio/io.table:
                     uesio.variant: uesio/appkit.main

--- a/bundle/views/lead_list.yaml
+++ b/bundle/views/lead_list.yaml
@@ -30,6 +30,9 @@ definition:
         uesio/crm.status:
         uesio/crm.source:
         uesio/crm.rating:
+        uesio/core.owner:
+          fields:
+            uesio/core.id: {}
       batchsize: 200
       order:
         - desc: true
@@ -62,6 +65,12 @@ definition:
                     searchFields:
                       - uesio/crm.firstname
                       - uesio/crm.lastname
+                - uesio/io.filter:
+                    uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
+                    wire: lead
+                    fieldId: uesio/core.owner
+                    labelPosition: none
+                    displayAs: MULTISELECT
                 - uesio/io.filter:
                     uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
                     wire: lead
@@ -142,6 +151,7 @@ definition:
                         width: 140px
                       - field: uesio/crm.status
                         readonly: true
+                      - {}
                     uesio.id: leadTable
                     wire: lead
                     pagesize: 10

--- a/bundle/views/lead_list.yaml
+++ b/bundle/views/lead_list.yaml
@@ -31,8 +31,6 @@ definition:
         uesio/crm.source:
         uesio/crm.rating:
         uesio/core.owner:
-          fields:
-            uesio/core.id: {}
       batchsize: 200
       order:
         - desc: true

--- a/bundle/views/lead_list.yaml
+++ b/bundle/views/lead_list.yaml
@@ -149,7 +149,6 @@ definition:
                         width: 140px
                       - field: uesio/crm.status
                         readonly: true
-                      - {}
                     uesio.id: leadTable
                     wire: lead
                     pagesize: 10

--- a/bundle/views/lead_list.yaml
+++ b/bundle/views/lead_list.yaml
@@ -30,7 +30,7 @@ definition:
         uesio/crm.status:
         uesio/crm.source:
         uesio/crm.rating:
-        uesio/core.owner:
+        uesio/core.owner: {}
       batchsize: 200
       order:
         - desc: true

--- a/bundle/views/opportunity_list.yaml
+++ b/bundle/views/opportunity_list.yaml
@@ -13,6 +13,7 @@ definition:
         uesio/crm.contact:
         uesio/crm.initials:
         uesio/crm.stage:
+        uesio/core.owner: {}
       batchsize: 200
       order:
         - desc: true
@@ -45,6 +46,12 @@ definition:
                     searchFields:
                       - uesio/crm.topic
                       - uesio/crm.account
+                - uesio/io.filter:
+                    uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
+                    wire: opportunity
+                    fieldId: uesio/core.owner
+                    labelPosition: none
+                    displayAs: MULTISELECT
                 - uesio/io.filter:
                     uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
                     wire: opportunity

--- a/bundle/views/task_list.yaml
+++ b/bundle/views/task_list.yaml
@@ -13,6 +13,7 @@ definition:
         uesio/crm.related_lead:
         uesio/crm.related_opportunity:
         uesio/crm.initials:
+        uesio/core.owner: {}
       batchsize: 200
       order:
         - desc: false
@@ -44,6 +45,12 @@ definition:
                     placeholder: Search Tasks
                     searchFields:
                       - uesio/crm.name
+                - uesio/io.filter:
+                    uesio.variant: uesio/io.customselectfield:uesio/appkit.filter
+                    wire: task
+                    fieldId: uesio/core.owner
+                    labelPosition: none
+                    displayAs: MULTISELECT
               content:
                 - uesio/io.table:
                     uesio.variant: uesio/appkit.main


### PR DESCRIPTION
This PR adds the owner filter to all table views:

- Leads
- Accounts
- Contacts
- Opportunities
- Tasks
- Events

It uses a multi-select filter pointing at the uesio/core.owner metadata to filter the records.
 